### PR TITLE
Http

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Provides CAS authentication for agents and/or clients on osTicket.
 
 Features
 ========
- - CAS extended attributes for user name and e-mail addresses.
+ - CAS or HTTP extended attributes for user name and e-mail addresses.
  - Optionally appending a suffix to user names to allow mapping to e-mail addresses.
  - Login for both agents and clients (can be toggled for neither, either, or both).
+ - Optionally redirect Agents to admin login through extended attributes for status.
  - Certificate validation (can be disabled for testing).
  - Auto creates clients if not already in osTicket.
 

--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -172,7 +172,7 @@ class CasStaffAuthBackend extends ExternalStaffAuthenticationBackend {
     function triggerAuth() {
         parent::triggerAuth();
         $cas = $this->cas->triggerAuth($this->getServiceUrl());
-        Http::redirect("scp/login.php");
+        Http::redirect("login.php");
     }
 }
 

--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -150,7 +150,7 @@ class CasStaffAuthBackend extends ExternalStaffAuthenticationBackend {
     function triggerAuth() {
         parent::triggerAuth();
         $cas = $this->cas->triggerAuth($this->getServiceUrl());
-        Http::redirect("scp/");
+        Http::redirect("scp/login.php");
     }
 }
 

--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -49,15 +49,23 @@ class CasAuth {
     }
 
     function setEmail() {
-        if($this->config->get('cas-email-attribute-key') !== null
-            && phpCAS::hasAttribute($this->config->get('cas-email-attribute-key'))) {
-            $_SESSION[':cas']['email'] = phpCAS::getAttribute(
-              $this->config->get('cas-email-attribute-key'));
-        } else {
-            $email = $this->getUser();
-            if($this->config->get('cas-at-domain') !== null) {
-                $email .= $this->config->get('cas-at-domain');
-            }
+        $email = $this->getUser();
+        switch($this->config->get('attr-provider')) {
+            case "cas" :
+                if($this->config->get('email-attribute-key') !== null
+                   && phpCAS::hasAttribute($this->config->get('email-attribute-key'))) {
+                    $_SESSION[':cas']['email'] = phpCAS::getAttribute($this->config->get('email-attribute-key'));
+                    break;
+                }
+            case "http" :
+                if($this->config->get('email-attribute-key') !== null && $_SERVER['HTTP_'.$this->config->get('email-attribute-key')] !== null) {
+                    $_SESSION[':cas']['email'] = $_SERVER['HTTP_'.$this->config->get('email-attribute-key')];
+                    break;
+                }
+            case "none" :
+                if($this->config->get('cas-at-domain') !== null) {
+                    $email .= $this->config->get('cas-at-domain');
+                }
             $_SESSION[':cas']['email'] = $email;
         }
     }
@@ -67,11 +75,18 @@ class CasAuth {
     }
 
     function setName() {
-        if($this->config->get('cas-name-attribute-key') !== null
-            && phpCAS::hasAttribute($this->config->get('cas-name-attribute-key'))) {
-            $_SESSION[':cas']['name'] = phpCAS::getAttribute(
-              $this->config->get('cas-name-attribute-key'));
-        } else {
+        switch($this->config->get('attr-provider')) {
+            case "cas" :
+                if($this->config->get('name-attribute-key') !== null
+                   && phpCAS::hasAttribute($this->config->get('name-attribute-key'))) {
+                    $_SESSION[':cas']['name'] = phpCAS::getAttribute($this->config->get('name-attribute-key'));
+                    break;
+                }
+            case "http" :
+                if($this->config->get('name-attribute-key') !== null && $_SERVER['HTTP_'.$this->config->get('name-attribute-key')] !== null) {
+                    $_SESSION[':cas']['name'] = $_SERVER['HTTP_'.$this->config->get('name-attribute-key')];
+                    break;
+                }
             $_SESSION[':cas']['name'] = $this->getUser();
         }
     }

--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -9,7 +9,7 @@ class CasAuth {
         $this->config = $config;
     }
 
-    function triggerAuth($service_url = false) {
+    function triggerAuth($service_url = null) {
         $self = $this;
         phpCAS::client(
           CAS_VERSION_2_0,
@@ -129,7 +129,7 @@ class CasStaffAuthBackend extends ExternalStaffAuthenticationBackend {
       if (!$cfg) {
         return null;
       }
-      return $cfg->getUrl() . "scp/";
+      return $cfg->getUrl() . "scp/login.php?do=ext&bk=cas";
     }
 
     function triggerAuth() {
@@ -187,7 +187,7 @@ class CasClientAuthBackend extends ExternalUserAuthenticationBackend {
       if (!$cfg) {
         return null;
       }
-      return $cfg->getUrl() . "login.php";
+      return $cfg->getUrl() . "login.php?do=ext&bk=cas.client";
     }
 
     function triggerAuth() {

--- a/auth-cas/config.php
+++ b/auth-cas/config.php
@@ -51,10 +51,10 @@ class CasPluginConfig extends PluginConfig {
             )),
             'cas-enabled' => clone $modes,
             'attr' => new SectionBreakField(array(
-                'label'=> $__('User Attributs'),
+                'label'=> $__('User Attributes'),
             )),
             'attr-provider' => new ChoiceField(array(
-                'label' => $__('Attribute Provider'),
+                'label' => $__('Attributes Provider'),
                 'default' => 'none',
                 'choices' => array(
                   'none' => $__('None'),

--- a/auth-cas/config.php
+++ b/auth-cas/config.php
@@ -76,6 +76,14 @@ class CasPluginConfig extends PluginConfig {
                 'hint' => $__('Use this field if your CAS server does not
                     report an e-mail attribute. ex: "@domain.tld"'),
             )),
+            'status-attribute-key' => new TextboxField(array(
+                'label' => $__('Status attribute key'),
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
+             'status-agent-value' => new TextboxField(array(
+                'label' => $__('Agent Status value'),
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
         );
     }
 }

--- a/auth-cas/config.php
+++ b/auth-cas/config.php
@@ -49,21 +49,33 @@ class CasPluginConfig extends PluginConfig {
                 'label' => $__('CAS CA Cert Path'),
                 'configuration' => array('size'=>60, 'length'=>100),
             )),
+            'cas-enabled' => clone $modes,
+            'attr' => new SectionBreakField(array(
+                'label'=> $__('User Attributs'),
+            )),
+            'attr-provider' => new ChoiceField(array(
+                'label' => $__('Attribute Provider'),
+                'default' => 'none',
+                'choices' => array(
+                  'none' => $__('None'),
+                  'cas' => $__('CAS'),
+                  'http' => $__('HTTP'),
+                  ),
+            )),    
+            'name-attribute-key' => new TextboxField(array(
+                'label' => $__('Name attribute key'),
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
+            'email-attribute-key' => new TextboxField(array(
+                'label' => $__('Email attribute key'),
+                'configuration' => array('size'=>60, 'length'=>100),
+            )),
             'cas-at-domain' => new TextboxField(array(
                 'label' => $__('CAS e-mail suffix'),
                 'configuration' => array('size'=>60, 'length'=>100),
                 'hint' => $__('Use this field if your CAS server does not
                     report an e-mail attribute. ex: "@domain.tld"'),
             )),
-            'cas-name-attribute-key' => new TextboxField(array(
-                'label' => $__('CAS name attribute key'),
-                'configuration' => array('size'=>60, 'length'=>100),
-            )),
-            'cas-email-attribute-key' => new TextboxField(array(
-                'label' => $__('CAS email attribute key'),
-                'configuration' => array('size'=>60, 'length'=>100),
-            )),
-            'cas-enabled' => clone $modes,
         );
     }
 }


### PR DESCRIPTION
Add the possibility to get usermail et username attributes through HTTP headers. Usefull with CAS server which can't handle cas attributes but which can send HTTP headers (for instance LemonLDAP::NG 1.4)
