### PR TITLE
Feature: Custom Attributes

### DIFF
--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -11,7 +11,7 @@ class CasAuth {
 
   private static function buildClient($hostname, $port, $context, $version) {
     if (CAS_DEBUG_MODE) {
-      phpCAS::setDebug('/tmp/phpCas.log');
+      phpCAS::setDebug(join(DIRECTORY_SEPARATOR, array(getenv('TEMP'), 'phpCAS.log')));
     }
     phpCAS::client(
       $version,
@@ -56,6 +56,7 @@ class CasAuth {
       $this->setUser();
       $this->setEmail();
       $this->setName();
+      $this->setCustomFields();
     }
   }
 
@@ -72,6 +73,8 @@ class CasAuth {
     }
   }
 
+  // NOTE: User in this context is CAS user, not osTicket username;
+  //       see getUsername() for osTicket username
   public function setUser() {
     $_SESSION[':cas']['user'] = phpCAS::getUser();
   }
@@ -113,10 +116,54 @@ class CasAuth {
     return $_SESSION[':cas']['name'];
   }
 
+  private function setCustomFields() {
+    $custom = array();
+    if($this->config->get('cas-custom-attributes') !== null) {
+      // parse rows by splitting newlines, then map to columns
+      $attrs = array_map('str_getcsv', str_getcsv($this->config->get('cas-custom-attributes'), "\n"));
+      // iterate over rows of ["claim-attribute", "form-field"]
+      foreach ($attrs as $x) {
+        // XXX: silently ignore incorrect column size and missing attrs
+        // XXX: does not disallow reserved fields user, email, name
+        if(count($x) == 2 && phpCAS::hasAttribute(trim($x[0]))) {
+          $custom[trim($x[1])] = phpCAS::getAttribute(trim($x[0]));
+        }
+      }
+    }
+    $_SESSION[':cas']['custom'] = json_encode($custom);
+  }
+
+  public function getCustomFields() {
+    return json_decode($_SESSION[':cas']['custom'], true, 2, JSON_THROW_ON_ERROR);
+  }
+
   public function getProfile() {
-    return array(
-      'email' => $this->getEmail(),
-      'name' => $this->getName());
+    return array_merge(
+      array(
+        'email' => $this->getEmail(),
+        'name' => $this->getName()
+      ), $this->getCustomFields());
+  }
+
+  public function getUsernameField() {
+    $field = $this->config->get('cas-username-form-field');
+    if($field === null) {
+      $field = 'email';
+    }
+    return $field;
+  }
+
+  // NOTE: Username in this context is osTicket username, not CAS user;
+  //       see getUser() for CAS user
+  public function getUsername() {
+    // NOTE: since this value is not cached, avoid calling too much
+    $info = $this->getProfile();
+    $info['user'] = $this->getUser();
+    $key = $this->getUsernameField();
+    if(array_key_exists($key, $info)) {
+      return $info[$key];
+    }
+    trigger_error("Username form field '$key' not found in user profile array", E_USER_ERROR);
   }
 }
 
@@ -147,8 +194,8 @@ class CasStaffAuthBackend extends ExternalStaffAuthenticationBackend {
   }
 
   function signOn() {
-    if (isset($_SESSION[':cas']['user'])) {
-      if (($staff = StaffSession::lookup($this->cas->getEmail()))
+    if (isset($_SESSION[':cas'])) {
+      if (($staff = StaffSession::lookup($this->cas->getUsername()))
         && $staff->getId()) {
         if (!$staff instanceof StaffSession) {
           // osTicket <= v1.9.7 or so
@@ -224,7 +271,8 @@ class CasClientAuthBackend extends ExternalUserAuthenticationBackend {
     global $cfg;
 
     if (isset($_SESSION[':cas'])) {
-      $acct = ClientAccount::lookupByUsername($this->cas->getEmail());
+      $username = $this->cas->getUsername();
+      $acct = ClientAccount::lookupByUsername($username);
       $client = null;
       if ($acct && $acct->getId()) {
         $client = new ClientSession(new EndUser($acct->getUser()));
@@ -232,7 +280,7 @@ class CasClientAuthBackend extends ExternalUserAuthenticationBackend {
 
       if (!$client) {
         $client = new ClientCreateRequest(
-          $this, $this->cas->getEmail(), $this->cas->getProfile());
+          $this, $username, $this->cas->getProfile());
         if (!$cfg || !$cfg->isClientRegistrationEnabled() && self::$config->get('cas-force-register')) {
           $client = $client->attemptAutoRegister();
         }

--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -122,7 +122,7 @@ class CasAuth {
       // parse rows by splitting newlines, then map to columns
       $attrs = array_map('str_getcsv', str_getcsv($this->config->get('cas-custom-attributes'), "\n"));
       // iterate over rows of ["claim-attribute", "form-field"]
-      foreach ($attrs as $x) {
+      foreach ($attrs as &$x) {
         // XXX: silently ignore incorrect column size and missing attrs
         // XXX: does not disallow reserved fields user, email, name
         if(count($x) == 2 && phpCAS::hasAttribute(trim($x[0]))) {

--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -118,7 +118,7 @@ class CasAuth {
 
   private function setCustomFields() {
     $custom = array();
-    if($this->config->get('cas-custom-attributes') !== null) {
+    if(!empty($this->config->get('cas-custom-attributes'))) {
       // parse rows by splitting newlines, then map to columns
       $attrs = array_map('str_getcsv', str_getcsv($this->config->get('cas-custom-attributes'), "\n"));
       // iterate over rows of ["claim-attribute", "form-field"]

--- a/auth-cas/config.php
+++ b/auth-cas/config.php
@@ -104,19 +104,24 @@ class CasPluginConfig extends PluginConfig {
     list($__, $_N) = self::translate();
 
     // test CSV
-    $attrs = array_map('str_getcsv', str_getcsv($config['cas-custom-attributes'], "\n"));
-    $username_field_choices = array('email', 'name');
-    // iterate over rows of ["claim-attribute", "form-field"]
-    for ($i = 0; $i < count($attrs); $i++) {
-      $x = &$attrs[$i];
-      if(count($x) != 2) {
-        $err = $__('Each line should be in form "claim-attribute,form-field"');
-      } elseif(in_array(trim($x[1]), $username_field_choices)) {
-        $err = sprintf($__('Do not map to form field "%s", set it in the options above'), trim($x[1]));
-      } else continue;
-      $this->getForm()->getField('cas-custom-attributes')->addError(sprintf($__('Line %d: '), $i + 1) . $err);
-      $errors['err'] = $__('Syntax error found in in custom attributes');
-      break;
+    $attrs = $config['cas-custom-attributes'];
+    if(empty(trim($attrs))) {
+      $config['cas-custom-attributes'] = '';
+    } else {
+      $attrs = array_map('str_getcsv', str_getcsv($config['cas-custom-attributes'], "\n"));
+      $username_field_choices = array('email', 'name');
+      // iterate over rows of ["claim-attribute", "form-field"]
+      for ($i = 0; $i < count($attrs); $i++) {
+        $x = &$attrs[$i];
+        if(count($x) != 2) {
+          $err = $__('Each line should be in form "claim-attribute,form-field"');
+        } elseif(in_array(trim($x[1]), $username_field_choices)) {
+          $err = sprintf($__('Do not map to form field "%s", set it in the options above'), trim($x[1]));
+        } else continue;
+        $this->getForm()->getField('cas-custom-attributes')->addError(sprintf($__('Line %d: '), $i + 1) . $err);
+        $errors['err'] = $__('Syntax error found in in custom attributes');
+        break;
+      }
     }
 
     global $msg;

--- a/auth-cas/config.php
+++ b/auth-cas/config.php
@@ -61,15 +61,33 @@ class CasPluginConfig extends PluginConfig {
         'label' => $__('Service label'),
         'configuration' => array('size'=>60, 'length'=>100),
         'hint' => $__('The text "Login with {label}" will appear on the login
-            button. By default this is "CAS".'))),
+          button. By default this is "CAS".'))),
       'cas-name-attribute-key' => new TextboxField(array(
         'label' => $__('Name attribute key'),
-        'configuration' => array('size'=>60, 'length'=>100))),
+        'configuration' => array('size'=>60, 'length'=>100),
+        'hint' => $__('This maps to the "name" form field.'))),
       'cas-email-attribute-key' => new TextboxField(array(
         'label' => $__('E-mail attribute key'),
-        'configuration' => array('size'=>60, 'length'=>100))),
+        'configuration' => array('size'=>60, 'length'=>100),
+        'hint' => $__('This maps to the "email" form field.'))),
+      'cas-custom-attributes' => new TextareaField(array(
+        'label' => $__('Custom attributes'),
+        'configuration' => array('cols'=>60, 'rows'=>5, 'length'=>1000,
+          'html'=>false, 'placeholder'=>
+            "sAMAccountName,adusername\nmobile,mobile"),
+        'hint' => $__('Extra attributes that are not required to set up an
+          account or sign in. Pass comma-delimited pairs of 2 in the form
+          "claim-attribute,form-field", one pair per line.'))),
+      'cas-username-form-field' => new TextboxField(array(
+        'label' => $__('Username form field'),
+        'configuration' => array('size'=>60, 'length'=>100),
+        'hint' => $__('This changes what username the account is assigned,
+          which affects both searching and provisioning. By default, this
+          is "email". "user", "name", and "email" are always available;
+          form fields mapped in "Custom attributes" above can also be used.'))),
       'cas-single-sign-off' => new BooleanField(array(
-        'label' => $__('Use single sign off'))),
+        'label' => $__('Use single sign off'),
+        'hint' => $__('Redirect to CAS sign out page when logging out of osTicket.'))),
       'cas-force-register' => new BooleanField(array(
         'label' => $__('Force client registration'),
         'hint' => $__('This is useful if you have public registration disabled.'))),

--- a/auth-cas/config.php
+++ b/auth-cas/config.php
@@ -4,6 +4,8 @@ require_once INCLUDE_DIR . 'class.plugin.php';
 // Include CAS to ensure that we pull in the constants.
 require_once(dirname(__file__).'/lib/jasig/phpcas/CAS.php');
 
+
+
 class CasPluginConfig extends PluginConfig {
 
   // Provide compatibility function for versions of osTicket prior to
@@ -70,6 +72,17 @@ class CasPluginConfig extends PluginConfig {
         'label' => $__('E-mail attribute key'),
         'configuration' => array('size'=>60, 'length'=>100),
         'hint' => $__('This maps to the "email" form field.'))),
+      'cas-username-form-field' => new ChoiceField(array(
+        'label' => $__('Username attribute'),
+        'default' => 'email',
+        'choices' => array(
+          'email' => $__('E-mail'),
+          'username' => $__('Username'),
+        ),
+        'hint' => $__('This changes what attribute is passed to osTicket as the
+          username, which affects both searching and provisioning. Assign a CAS attribute
+          to the "username" form field in "Custom attributes" below to use that attribute
+          instead of the CAS username.'))),
       'cas-custom-attributes' => new TextareaField(array(
         'label' => $__('Custom attributes'),
         'configuration' => array('cols'=>60, 'rows'=>5, 'length'=>1000,
@@ -78,13 +91,6 @@ class CasPluginConfig extends PluginConfig {
         'hint' => $__('Extra attributes that are not required to set up an
           account or sign in. Pass comma-delimited pairs of 2 in the form
           "claim-attribute,form-field", one pair per line.'))),
-      'cas-username-form-field' => new TextboxField(array(
-        'label' => $__('Username form field'),
-        'configuration' => array('size'=>60, 'length'=>100),
-        'hint' => $__('This changes what username the account is assigned,
-          which affects both searching and provisioning. By default, this
-          is "email". "user", "name", and "email" are always available;
-          form fields mapped in "Custom attributes" above can also be used.'))),
       'cas-single-sign-off' => new BooleanField(array(
         'label' => $__('Use single sign off'),
         'hint' => $__('Redirect to CAS sign out page when logging out of osTicket.'))),
@@ -92,5 +98,31 @@ class CasPluginConfig extends PluginConfig {
         'label' => $__('Force client registration'),
         'hint' => $__('This is useful if you have public registration disabled.'))),
       'cas-enabled' => clone $modes);
+  }
+
+  function pre_save(&$config, &$errors) {
+    list($__, $_N) = self::translate();
+
+    // test CSV
+    $attrs = array_map('str_getcsv', str_getcsv($config['cas-custom-attributes'], "\n"));
+    $username_field_choices = array('email', 'name');
+    // iterate over rows of ["claim-attribute", "form-field"]
+    for ($i = 0; $i < count($attrs); $i++) {
+      $x = &$attrs[$i];
+      if(count($x) != 2) {
+        $err = $__('Each line should be in form "claim-attribute,form-field"');
+      } elseif(in_array(trim($x[1]), $username_field_choices)) {
+        $err = sprintf($__('Do not map to form field "%s", set it in the options above'), trim($x[1]));
+      } else continue;
+      $this->getForm()->getField('cas-custom-attributes')->addError(sprintf($__('Line %d: '), $i + 1) . $err);
+      $errors['err'] = $__('Syntax error found in in custom attributes');
+      break;
+    }
+
+    global $msg;
+    if (!$errors)
+      $msg = $__('CAS configuration updated successfully');
+
+    return !$errors;
   }
 }

--- a/auth-cas/plugin.php
+++ b/auth-cas/plugin.php
@@ -1,7 +1,7 @@
 <?php
 return array(
   'id' =>             'auth:cas', # notrans
-  'version' =>        '1.1.8-rc1',
+  'version' =>        '1.1.7',
   'name' =>           /* trans */ 'JASIG CAS Authentication',
   'author' =>         'Kevin O\'Connor',
   'description' =>    /* trans */ 'Provides a configurable authentication

--- a/auth-cas/plugin.php
+++ b/auth-cas/plugin.php
@@ -1,7 +1,7 @@
 <?php
 return array(
   'id' =>             'auth:cas', # notrans
-  'version' =>        '1.1.7',
+  'version' =>        '1.1.8-rc1',
   'name' =>           /* trans */ 'JASIG CAS Authentication',
   'author' =>         'Kevin O\'Connor',
   'description' =>    /* trans */ 'Provides a configurable authentication
@@ -10,7 +10,7 @@ return array(
   'plugin' =>         'authentication.php:CasAuthPlugin',
   'requires' => array(
     "jasig/phpcas" => array(
-      "version" => "1.3.5",
+      "version" => "1.3.8",
       "map" => array(
         "jasig/phpcas/source" => 'lib/jasig/phpcas',
         )


### PR DESCRIPTION
This branch adds a custom attributes option that allows users to pull in additional CAS claims. It also adds an option to change the assigned username, as setting it to the email address was not playing nice with the LDAP plugin and we use both in my environment. This means you can set the osTicket username to whatever you want, even the value of a custom claim attribute.

`phpCAS` version has also been updated from 1.3.5 to 1.3.8 with no adverse affects, and the removal of a warning that was causing issues in my development environment.

During testing I needed to see the `phpCAS.log` but we are using IIS, so I had to change that string to get it to work. Instead, I thought it would be better to use `$TEMP` to make it platform-independent.

While editing the config page I also added some help text for some other options to make them more clear. 

First time CAS and PHP user, so let me know if I did anything wrong :)