### PR TITLE
fix: ensure Config::tranlate() is static

### DIFF
--- a/auth-cas/config.php
+++ b/auth-cas/config.php
@@ -10,7 +10,7 @@ class CasPluginConfig extends PluginConfig {
 
   // Provide compatibility function for versions of osTicket prior to
   // translation support (v1.9.4)
-  function translate() {
+  static function translate() {
     if (!method_exists('Plugin', 'translate')) {
       return array(
         function($x) { return $x; },


### PR DESCRIPTION
When updating to osTicket 1.16, i got this error when editing a staff member

![image](https://user-images.githubusercontent.com/37900449/166685708-9b46138c-1ea5-4476-9cf6-46b40c706397.png)

This bug prevented all edits on staff member and was due to the fact that the function translate was not declared static. I've tested the fix by repacking the phar and redployed it to my server, and it worked.