### PR TITLE
fix: rename config to cas_config in CasClientAuthBackend and CasStaffAuthBackend

### DIFF
--- a/auth-cas/cas.php
+++ b/auth-cas/cas.php
@@ -179,22 +179,22 @@ class CasStaffAuthBackend extends ExternalStaffAuthenticationBackend {
 
   static $service_name = "CAS";
 
-  private static $config;
+  private static $cas_config;
 
   function __construct() {
-    $this->cas = new CasAuth(self::$config);
-    $customLabel = self::$config->get('cas-service-label');
+    $this->cas = new CasAuth(self::$cas_config);
+    $customLabel = self::$cas_config->get('cas-service-label');
     if (!empty($customLabel)) {
       self::$service_name = $customLabel;
     }
   }
 
   public static function bootstrap($config) {
-    self::$config = $config;
+    self::$cas_config = $config;
   }
 
   function getName() {
-    $config = self::$config;
+    $config = self::$cas_config;
     list($__, $_N) = $config::translate();
     return $__(static::$name);
   }
@@ -223,7 +223,7 @@ class CasStaffAuthBackend extends ExternalStaffAuthenticationBackend {
     if ($cfg != null && !empty(trim($cfg->getUrl()))) {
       $return_url = $cfg->getUrl() . "scp/login.php";
     }
-    CasAuth::signOut(self::$config, $return_url);
+    CasAuth::signOut(self::$cas_config, $return_url);
   }
 
   function getServiceUrl() {
@@ -248,23 +248,23 @@ class CasClientAuthBackend extends ExternalUserAuthenticationBackend {
 
   static $service_name = "CAS";
 
-  private static $config;
+  private static $cas_config;
 
   function __construct() {
-    $this->cas = new CasAuth(self::$config);
+    $this->cas = new CasAuth(self::$cas_config);
 
-    $customLabel = self::$config->get('cas-service-label');
+    $customLabel = self::$cas_config->get('cas-service-label');
     if (!empty($customLabel)) {
       self::$service_name = $customLabel;
     }
   }
 
   public static function bootstrap($config) {
-    self::$config = $config;
+    self::$cas_config = $config;
   }
 
   function getName() {
-    $config = self::$config;
+    $config = self::$cas_config;
     list($__, $_N) = $config::translate();
     return $__(static::$name);
   }
@@ -287,7 +287,7 @@ class CasClientAuthBackend extends ExternalUserAuthenticationBackend {
       if (!$client) {
         $client = new ClientCreateRequest(
           $this, $username, $this->cas->getProfile());
-        if (!$cfg || !$cfg->isClientRegistrationEnabled() && self::$config->get('cas-force-register')) {
+        if (!$cfg || !$cfg->isClientRegistrationEnabled() && self::$cas_config->get('cas-force-register')) {
           $client = $client->attemptAutoRegister();
         }
       }
@@ -304,7 +304,7 @@ class CasClientAuthBackend extends ExternalUserAuthenticationBackend {
     if ($cfg != null && !empty(trim($cfg->getUrl()))) {
       $return_url = $cfg->getUrl() . "login.php";
     }
-    CasAuth::signOut(self::$config, $return_url);
+    CasAuth::signOut(self::$cas_config, $return_url);
   }
 
   function getServiceUrl() {


### PR DESCRIPTION
# Symptom

When updating to osTicket 1.17, several users got the following error : `Fatal error: Cannot redeclare non static AuthenticationBackend::$config as static CasStaffAuthBackend::$config in phar://C:/include/plugins/auth-cas.phar/cas.php`. See issue #35 

# Cause

After investigating, it appears that 6 month ago during the development of the multi-instance feature, the following commit was issued to the core osTicket repo : https://github.com/osTicket/osTicket/commit/0b93b48ec6c821e9f182ab2a830ca0adcf24138a. This commit created a new protected attribute `config` for the `AuthenticationBackend` class.

However, in the auth-cas plugin, the `CasStaffAuthBackend` and `CasClientAuthBackend` both have an already declared `config` attribute since 7 years, and extends respectively osTicket classes `ExternalStaffAuthenticationBackend` and `ExternalUserAuthenticationBackend`, which in turn extends respectively `StaffAuthenticationBackend` and `UserAuthenticationBackend` which in turn extends `AuthenticationBackend` which had the new `config` attribute. This attribute being only protected, it went all the way down to our classes : `CasStaffAuthBackend` and `CasClientAuthBackend`, conflicting with their `config` attribute.

# Solution

Our attribute being private, the easiest solution I have thinked of is changing the name of our variable `config` to `cas_config` in our two classes `CasStaffAuthBackend` and `CasClientAuthBackend`. Because they are private, they can only be accessed within the source code of theses two classes, so the scope of the fix keeps limited and simple.

# Tests

Phar successfully rebuilt and works under osticket v1.17

# Additional question

@kevinoconnor7 I can try to provide some fixes or updates as I already done in #33 while being a maintainer of this repo with you if you wish.

I would like to try this things :

* update dependancies / check link with the https://github.com/osTicket/osTicket-plugins repo. Because of it we are stuck to https://github.com/apereo/phpCAS 1.3.8 whereas the 1.6.0 has just been released
* relaunching releases process (bump new versions, ensuring cicleci still working or moving to github actions or whatever),
* provide issues and PR templates
* check the possibility of disabling the login form for client and keep only the cas button
* check issues and fix what can be fixed

That would be already enough for now !